### PR TITLE
Fix for YouTube's next/previous song switching according to new Web Interface

### DIFF
--- a/modules/web/src/main/java/me/aap/fermata/addon/web/yt/YoutubeWebView.java
+++ b/modules/web/src/main/java/me/aap/fermata/addon/web/yt/YoutubeWebView.java
@@ -126,14 +126,14 @@ public class YoutubeWebView extends FermataWebView {
 	}
 
 	void prev() {
-		prevNext(0, 0);
+		prevNext(0);
 	}
 
 	void next() {
-		prevNext(4, 1);
+		prevNext(1);
 	}
 
-	private void prevNext(int idx, int plIdx) {
+	private void prevNext(int plIdx) {
 		FermataChromeClient chrome = getWebChromeClient();
 		if (chrome == null) return;
 

--- a/modules/web/src/main/java/me/aap/fermata/addon/web/yt/YoutubeWebView.java
+++ b/modules/web/src/main/java/me/aap/fermata/addon/web/yt/YoutubeWebView.java
@@ -139,20 +139,23 @@ public class YoutubeWebView extends FermataWebView {
 
 		chrome.exitFullScreen().thenRun(() -> loadUrl("""
 			javascript:
+			function changeSong() {
+				""" + (plIdx == 0 ? """
+				var prevSong = document.querySelector('.ytm-playlist-panel-video-renderer-v2--selected').previousSibling;
+				if (prevSong !== null) prevSong.getElementsByTagName('a')[0].click();
+				""" : """
+				var nextSong = document.querySelector('.ytm-playlist-panel-video-renderer-v2--selected').nextSibling;
+				if (nextSong !== null) nextSong.getElementsByTagName('a')[0].click();
+				""") + """
+			}
+			
 			if (document.getElementsByTagName('ytm-playlist-engagement-panel').length > 0) {
 				if (document.body.getAttribute('engagement-panel-open') === null) {
 					setTimeout(() => {document.querySelector('[aria-label="Show playlist videos"]').click();}, 600);
+					setTimeout(() => { changeSong(); }, 600);
 				}
 				
-				setTimeout(() => {
-					""" + (plIdx == 0 ? """
-					var prevSong = document.querySelector('.ytm-playlist-panel-video-renderer-v2--selected').previousSibling;
-					if (prevSong !== null) prevSong.getElementsByTagName('a')[0].click();
-					""" : """
-					var nextSong = document.querySelector('.ytm-playlist-panel-video-renderer-v2--selected').nextSibling;
-					if (nextSong !== null) nextSong.getElementsByTagName('a')[0].click();
-					""") + """
-				}, 600);
+				changeSong();
 			} else {
 				var playerControls = document.getElementsByClassName('player-controls-middle-core-buttons');
 				if (playerControls.length > 0) {


### PR DESCRIPTION
### Hi, @AndreyPavlenko I implemented a fix for this [issue](https://github.com/AndreyPavlenko/Fermata/issues/301). Can you please test and approve the Pull Request?

#### Let me explain how it works:
- Checks if currently a playlist is playing, executes the if statement, otherwise, it executes the else statement.
- If a playlist is playing, and the user wants to switch the song, it finds the currently selected song from the playlist, fetches its next/previous sibling (based on user input), and clicks the ```a``` tag inside it.
- If the video being played is not part of a playlist, it finds the video player controls and clicks on the next/previous control button (this is extracted using ```aria-label```) based on user input.

#### Something different:
- I used ```Tripple quotes escaping``` to write the js code :D
- Also I did not know what the ```idx``` parameter does, so I didn't use it.

Also, the Timeouts are added to wait for the animations to complete.

_PS: Eagerly waiting for the new build :D_