### PR TITLE
Fix for YouTube's next/previous song switching - selected class broken in mobile view

### DIFF
--- a/modules/web/src/main/java/me/aap/fermata/addon/web/yt/YoutubeWebView.java
+++ b/modules/web/src/main/java/me/aap/fermata/addon/web/yt/YoutubeWebView.java
@@ -126,14 +126,14 @@ public class YoutubeWebView extends FermataWebView {
 	}
 
 	void prev() {
-		prevNext(0, 0);
+		prevNext(0);
 	}
 
 	void next() {
-		prevNext(4, 1);
+		prevNext(1);
 	}
 
-	private void prevNext(int idx, int plIdx) {
+	private void prevNext(int plIdx) {
 		FermataChromeClient chrome = getWebChromeClient();
 		if (chrome == null) return;
 

--- a/modules/web/src/main/java/me/aap/fermata/addon/web/yt/YoutubeWebView.java
+++ b/modules/web/src/main/java/me/aap/fermata/addon/web/yt/YoutubeWebView.java
@@ -137,16 +137,31 @@ public class YoutubeWebView extends FermataWebView {
 		FermataChromeClient chrome = getWebChromeClient();
 		if (chrome == null) return;
 
+		String url = chrome.getWebView().getUrl();
 		chrome.exitFullScreen().thenRun(() -> loadUrl("""
 			javascript:
 			function changeSong() {
-				""" + (plIdx == 0 ? """
-				var prevSong = document.querySelector('.ytm-playlist-panel-video-renderer-v2--selected').previousSibling;
-				if (prevSong !== null) prevSong.getElementsByTagName('a')[0].click();
-				""" : """
-				var nextSong = document.querySelector('.ytm-playlist-panel-video-renderer-v2--selected').nextSibling;
-				if (nextSong !== null) nextSong.getElementsByTagName('a')[0].click();
-				""") + """
+				var currentURL ='""" + url + """
+				';var videoID = currentURL.substring(currentURL.indexOf("v=") + 2, currentURL.indexOf("&"));
+					
+				var playlist = document.getElementsByClassName('ytm-playlist-panel-video-renderer-v2');
+				var currentlySelected;
+				for (song of playlist) {
+					if (song.querySelector(`a[href*='${videoID}']`)) {
+						currentlySelected = song;
+						break;
+					}
+				}
+				
+				if (currentlySelected) {
+					""" + (plIdx == 0 ? """
+					var prevSong = currentlySelected.previousSibling;
+					if (prevSong !== null) prevSong.getElementsByTagName('a')[0].click();
+					""" : """
+					var nextSong = currentlySelected.nextSibling;
+					if (nextSong !== null) nextSong.getElementsByTagName('a')[0].click();
+					""") + """
+				}
 			}
 			
 			if (document.getElementsByTagName('ytm-playlist-engagement-panel').length > 0) {

--- a/modules/web/src/main/java/me/aap/fermata/addon/web/yt/YoutubeWebView.java
+++ b/modules/web/src/main/java/me/aap/fermata/addon/web/yt/YoutubeWebView.java
@@ -139,20 +139,23 @@ public class YoutubeWebView extends FermataWebView {
 
 		chrome.exitFullScreen().thenRun(() -> loadUrl("""
 			javascript:
+			function changeSong() {
+				""" + (plIdx == 0 ? """
+				var prevSong = document.querySelector('.ytm-playlist-panel-video-renderer-v2--selected').previousSibling;
+				if (prevSong !== null) prevSong.getElementsByTagName('a')[0].click();
+				""" : """
+				var nextSong = document.querySelector('.ytm-playlist-panel-video-renderer-v2--selected').nextSibling;
+				if (nextSong !== null) nextSong.getElementsByTagName('a')[0].click();
+				""") + """
+			}
+			
 			if (document.getElementsByTagName('ytm-playlist-engagement-panel').length > 0) {
 				if (document.body.getAttribute('engagement-panel-open') === null) {
 					setTimeout(() => {document.querySelector('[aria-label="Show playlist videos"]').click();}, 600);
+					setTimeout(() => { changeSong(); }, 600);
 				}
 				
-				setTimeout(() => {
-					""" + (plIdx == 0 ? """
-					var prevSong = document.querySelector('.ytm-playlist-panel-video-renderer-v2--selected').previousSibling;
-					if (prevSong !== null) prevSong.getElementsByTagName('a')[0].click();
-					""" : """
-					var nextSong = document.querySelector('.ytm-playlist-panel-video-renderer-v2--selected').nextSibling;
-					if (nextSong !== null) nextSong.getElementsByTagName('a')[0].click();
-					""") + """
-				}, 600);
+				changeSong();
 			} else {
 				var playerControls = document.getElementsByClassName('player-controls-middle-core-buttons');
 				if (playerControls.length > 0) {


### PR DESCRIPTION
## Hi @AndreyPavlenko, here is another fix for the song switching issue.

I have been having an issue for like a week and finally fixed it. On the mobile view of YouTube's website, there is a bug that when you switch to next song in a playlist, the selected tile doesn't change properly in the playlist (this occurs even in chrome browser not an app specific issue - see the video attached) and this PR implements a way to get around this problem and fix the song switching in the app.

### What has changed:
Instead of finding the selected song using class selection, I get the video ID from URL and the list of songs from playlist. Then I find the current song from playlist using that video ID and rest is the same, getting it's next or previous sibling and click on it.

[30.12.2023 17_51.webm](https://github.com/AndreyPavlenko/Fermata/assets/73714615/d406d6ef-fd55-4175-807f-61d0050dd9cf)
