### PR TITLE
Add sponsorblock support

### DIFF
--- a/modules/web/src/main/java/me/aap/fermata/addon/web/yt/YoutubeSponsorBlock.java
+++ b/modules/web/src/main/java/me/aap/fermata/addon/web/yt/YoutubeSponsorBlock.java
@@ -80,7 +80,9 @@ final class YoutubeSponsorBlock {
 				getCategoriesJson(ps) + ",\"actionTypes\":[\"skip\"]}";
 	}
 
-	static String getScript(Context ctx) {
+	static String getScript(Context ctx, PreferenceStore ps) {
+		if (!ps.getBooleanPref(ENABLED)) return "";
+
 		String s = script;
 		if (s != null) return s;
 

--- a/modules/web/src/main/java/me/aap/fermata/addon/web/yt/YoutubeWebView.java
+++ b/modules/web/src/main/java/me/aap/fermata/addon/web/yt/YoutubeWebView.java
@@ -74,7 +74,7 @@ public class YoutubeWebView extends FermataWebView {
 			else clearHighestVideoQuality();
 		}
 
-		if (YoutubeSponsorBlock.isPreferenceChanged(prefs)) configureSponsorBlock();
+		if (YoutubeSponsorBlock.isPreferenceChanged(prefs)) injectSponsorBlock();
 	}
 
 	@Override
@@ -135,8 +135,9 @@ public class YoutubeWebView extends FermataWebView {
 	}
 
 	private void injectSponsorBlock() {
-		String script = YoutubeSponsorBlock.getScript(getContext());
+		String script = YoutubeSponsorBlock.getScript(getContext(), getAddon().getPreferenceStore());
 		if (!script.isEmpty()) evaluateJavascript(script, result -> configureSponsorBlock());
+		else configureSponsorBlock();
 	}
 
 	private void configureSponsorBlock() {

--- a/modules/web/src/main/res/raw/youtube_sponsorblock.js
+++ b/modules/web/src/main/res/raw/youtube_sponsorblock.js
@@ -154,16 +154,15 @@
 
       if (response.status === 404) {
         state.segments = [];
+        state.loadedKey = key;
       } else if (response.ok) {
         state.segments = normalizeSegments(segmentsForVideo(await response.json(), videoId));
+        state.loadedKey = key;
       } else {
         console.debug('SponsorBlock request failed', response.status);
       }
-
-      state.loadedKey = key;
     } catch (err) {
       console.debug('SponsorBlock unavailable', err);
-      state.loadedKey = key;
     } finally {
       if (state.pendingKey === key) state.pendingKey = null;
     }


### PR DESCRIPTION
Implements sponsorblock according to https://wiki.sponsor.ajay.app/w/API_Docs docs. Allows user to customise segments to auto skip

Solves https://github.com/AndreyPavlenko/Fermata/issues/672