### PR TITLE
Use branch-specific package ids for Auto test builds

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -94,11 +94,12 @@ jobs:
           mkdir -p dist/arm64 dist/arm
           echo "App name: $APP_NAME"
           echo "Package suffix: $APP_ID_SFX"
-          ./gradlew fermata:packageAutoReleaseUniversalApk -PABI=arm64-v8a \
-            -PAPP_ID_SFX="$APP_ID_SFX" -PAPP_NAME="$APP_NAME" --build-cache
+          ARGS=(--build-cache)
+           [ -z "$APP_NAME" ] || ARGS+=("-PAPP_NAME=$APP_NAME")
+           [ -z "$APP_ID_SFX" ] || ARGS+=("-PAPP_ID_SFX=$APP_ID_SFX")
+           ./gradlew fermata:packageAutoReleaseUniversalApk -PABI=arm64-v8a "${ARGS[@]}"
           mv $out/*.apk dist/arm64/
-          ./gradlew fermata:packageAutoReleaseUniversalApk -PABI=armeabi-v7a \
-            -PAPP_ID_SFX="$APP_ID_SFX" -PAPP_NAME="$APP_NAME" --build-cache
+          ./gradlew fermata:packageAutoReleaseUniversalApk -PABI=armeabi-v7a "${ARGS[@]}"
           mv $out/*.apk dist/arm/
 
       - name: Upload arm64 APK

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -34,6 +34,10 @@ jobs:
           echo "ANDROID_NDK_VERSION=$(version ndkVersion)-$git_hash" >> $GITHUB_ENV
 
       - name: Export vars
+        env:
+          APP_NAME: ${{ vars.APP_NAME }}
+          APP_ID_SFX: ${{ vars.APP_ID_SFX }}
+          ARTIFACT_SFX: ${{ vars.ARTIFACT_SFX }}
         run: |
           export_vars() {
             for name in "$@"; do

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -33,6 +33,31 @@ jobs:
           echo "APP_VERSION=$app_version" >> $GITHUB_ENV
           echo "ANDROID_NDK_VERSION=$(version ndkVersion)-$git_hash" >> $GITHUB_ENV
 
+      - name: Prepare test build identifiers
+        env:
+          BRANCH_OWNER: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        run: |
+          sanitize_package_segment() {
+            local value prefix
+            value="$1"
+            prefix="$2"
+            value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' |
+              sed -E 's/[^a-z0-9]+/_/g; s/^_+//; s/_+$//; s/_+/_/g')"
+            [ -n "$value" ] || value="test"
+            printf '%s%s' "$prefix" "$value"
+          }
+
+          owner_slug="$(sanitize_package_segment "$BRANCH_OWNER" o)"
+          branch_slug="$(sanitize_package_segment "$BRANCH_NAME" b)"
+          label_owner="${owner_slug#o}"
+          label_branch="${branch_slug#b}"
+          short_sha="$(git rev-parse --short HEAD)"
+
+          echo "APP_ID_SFX=.test.${owner_slug}.${branch_slug}" >> $GITHUB_ENV
+          echo "APP_NAME_SFX= (${label_owner}-${label_branch}@${short_sha})" >> $GITHUB_ENV
+          echo "ARTIFACT_SFX=-${owner_slug}-${branch_slug}" >> $GITHUB_ENV
+
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:
@@ -72,15 +97,19 @@ jobs:
         run: |
           out=fermata/build/outputs/apk_from_bundle/autoRelease
           mkdir -p dist/arm64 dist/arm
-          ./gradlew fermata:packageAutoReleaseUniversalApk -PABI=arm64-v8a --build-cache
+          echo "Using package suffix: $APP_ID_SFX"
+          echo "Using app name suffix: $APP_NAME_SFX"
+          ./gradlew fermata:packageAutoReleaseUniversalApk -PABI=arm64-v8a \
+            -PAPP_ID_SFX="$APP_ID_SFX" -PAPP_NAME_SFX="$APP_NAME_SFX" --build-cache
           mv $out/*.apk dist/arm64/
-          ./gradlew fermata:packageAutoReleaseUniversalApk -PABI=armeabi-v7a --build-cache
+          ./gradlew fermata:packageAutoReleaseUniversalApk -PABI=armeabi-v7a \
+            -PAPP_ID_SFX="$APP_ID_SFX" -PAPP_NAME_SFX="$APP_NAME_SFX" --build-cache
           mv $out/*.apk dist/arm/
 
       - name: Upload arm64 APK
         uses: actions/upload-artifact@v4
         with:
-          name: fermata-auto-${{ env.APP_VERSION }}-arm64
+          name: fermata-auto-test-${{ env.APP_VERSION }}${{ env.ARTIFACT_SFX }}-arm64
           path: dist/arm64/*.apk
           retention-days: 30
           if-no-files-found: error
@@ -88,7 +117,7 @@ jobs:
       - name: Upload arm APK
         uses: actions/upload-artifact@v4
         with:
-          name: fermata-auto-${{ env.APP_VERSION }}-arm
+          name: fermata-auto-test-${{ env.APP_VERSION }}${{ env.ARTIFACT_SFX }}-arm
           path: dist/arm/*.apk
           retention-days: 30
           if-no-files-found: error

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -35,9 +35,15 @@ jobs:
 
       - name: Export vars
         run: |
-          [ -z "${{ vars.APP_NAME }}" ] || echo "APP_NAME=${{ vars.APP_NAME == 'none' ? '' : vars.APP_NAME }}" >> "$GITHUB_ENV"
-          [ -z "${{ vars.APP_ID_SFX }}" ] || echo "APP_ID_SFX=${{ vars.APP_ID_SFX == 'none' ? '' : vars.APP_ID_SFX }}" >> "$GITHUB_ENV"
-          [ -z "${{ vars.ARTIFACT_SFX }}" ] || echo "ARTIFACT_SFX=${{ vars.ARTIFACT_SFX == 'none' ? '' : vars.ARTIFACT_SFX }}" >> "$GITHUB_ENV"
+          export_vars() {
+            for name in "$@"; do
+              local value="${!name}"
+              [ -z "$value" ] && continue
+              [ "$value" = "none" ] && value=""
+              echo "$name=$value" >> "$GITHUB_ENV"
+            done
+          }
+          export_vars APP_NAME APP_ID_SFX ARTIFACT_SFX
 
       - name: Prepare build identifiers
         env:

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -33,6 +33,12 @@ jobs:
           echo "APP_VERSION=$app_version" >> $GITHUB_ENV
           echo "ANDROID_NDK_VERSION=$(version ndkVersion)-$git_hash" >> $GITHUB_ENV
 
+      - name: Export vars
+        run: |
+          [ -z "${{ vars.APP_NAME }}" ] || echo "APP_NAME=${{ vars.APP_NAME == 'none' ? '' : vars.APP_NAME }}" >> "$GITHUB_ENV"
+          [ -z "${{ vars.APP_ID_SFX }}" ] || echo "APP_ID_SFX=${{ vars.APP_ID_SFX == 'none' ? '' : vars.APP_ID_SFX }}" >> "$GITHUB_ENV"
+          [ -z "${{ vars.ARTIFACT_SFX }}" ] || echo "ARTIFACT_SFX=${{ vars.ARTIFACT_SFX == 'none' ? '' : vars.ARTIFACT_SFX }}" >> "$GITHUB_ENV"
+
       - name: Prepare build identifiers
         env:
           BRANCH_OWNER: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -33,30 +33,25 @@ jobs:
           echo "APP_VERSION=$app_version" >> $GITHUB_ENV
           echo "ANDROID_NDK_VERSION=$(version ndkVersion)-$git_hash" >> $GITHUB_ENV
 
-      - name: Prepare test build identifiers
+      - name: Prepare build identifiers
         env:
           BRANCH_OWNER: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
+          [ -v APP_NAME ] && [ -v APP_ID_SFX ] && [ -v ARTIFACT_SFX ] && exit 0
+
           sanitize_package_segment() {
-            local value prefix
-            value="$1"
-            prefix="$2"
-            value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' |
-              sed -E 's/[^a-z0-9]+/_/g; s/^_+//; s/_+$//; s/_+/_/g')"
-            [ -n "$value" ] || value="test"
-            printf '%s%s' "$prefix" "$value"
+            tr '[:upper:]' '[:lower:]' <<< "$1" \
+              | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g; s/_+/_/g; s/^([0-9])/x\1/'
           }
 
-          owner_slug="$(sanitize_package_segment "$BRANCH_OWNER" o)"
-          branch_slug="$(sanitize_package_segment "$BRANCH_NAME" b)"
-          label_owner="${owner_slug#o}"
-          label_branch="${branch_slug#b}"
-          short_sha="$(git rev-parse --short HEAD)"
+          owner="$(sanitize_package_segment "$BRANCH_OWNER")"
+          branch="$(sanitize_package_segment "$BRANCH_NAME")"
+          sha="$(git rev-parse --short HEAD)"
 
-          echo "APP_ID_SFX=.test.${owner_slug}.${branch_slug}" >> $GITHUB_ENV
-          echo "APP_NAME_SFX= (${label_owner}-${label_branch}@${short_sha})" >> $GITHUB_ENV
-          echo "ARTIFACT_SFX=-${owner_slug}-${branch_slug}" >> $GITHUB_ENV
+          [ -v APP_NAME ] || echo "APP_NAME=Fermata Auto (${BRANCH_OWNER}-${sha})" >> "$GITHUB_ENV"
+          [ -v APP_ID_SFX ] || echo "APP_ID_SFX=.${owner}" >> "$GITHUB_ENV"
+          [ -v ARTIFACT_SFX ] || echo "ARTIFACT_SFX=-${owner}-${branch}-${sha}" >> "$GITHUB_ENV"
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
@@ -109,7 +104,7 @@ jobs:
       - name: Upload arm64 APK
         uses: actions/upload-artifact@v4
         with:
-          name: fermata-auto-test-${{ env.APP_VERSION }}${{ env.ARTIFACT_SFX }}-arm64
+          name: fermata-auto-${{ env.APP_VERSION }}${{ env.ARTIFACT_SFX }}-arm64
           path: dist/arm64/*.apk
           retention-days: 30
           if-no-files-found: error
@@ -117,7 +112,7 @@ jobs:
       - name: Upload arm APK
         uses: actions/upload-artifact@v4
         with:
-          name: fermata-auto-test-${{ env.APP_VERSION }}${{ env.ARTIFACT_SFX }}-arm
+          name: fermata-auto-${{ env.APP_VERSION }}${{ env.ARTIFACT_SFX }}-arm
           path: dist/arm/*.apk
           retention-days: 30
           if-no-files-found: error

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -51,7 +51,7 @@ jobs:
 
           [ -v APP_NAME ] || echo "APP_NAME=Fermata Auto (${BRANCH_OWNER}-${sha})" >> "$GITHUB_ENV"
           [ -v APP_ID_SFX ] || echo "APP_ID_SFX=.${owner}" >> "$GITHUB_ENV"
-          [ -v ARTIFACT_SFX ] || echo "ARTIFACT_SFX=-${owner}-${branch}-${sha}" >> "$GITHUB_ENV"
+          [ -v ARTIFACT_SFX ] || echo "ARTIFACT_SFX=-${owner}-${branch}" >> "$GITHUB_ENV"
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -92,13 +92,13 @@ jobs:
         run: |
           out=fermata/build/outputs/apk_from_bundle/autoRelease
           mkdir -p dist/arm64 dist/arm
-          echo "Using package suffix: $APP_ID_SFX"
-          echo "Using app name suffix: $APP_NAME_SFX"
+          echo "App name: $APP_NAME"
+          echo "Package suffix: $APP_ID_SFX"
           ./gradlew fermata:packageAutoReleaseUniversalApk -PABI=arm64-v8a \
-            -PAPP_ID_SFX="$APP_ID_SFX" -PAPP_NAME_SFX="$APP_NAME_SFX" --build-cache
+            -PAPP_ID_SFX="$APP_ID_SFX" -PAPP_NAME="$APP_NAME" --build-cache
           mv $out/*.apk dist/arm64/
           ./gradlew fermata:packageAutoReleaseUniversalApk -PABI=armeabi-v7a \
-            -PAPP_ID_SFX="$APP_ID_SFX" -PAPP_NAME_SFX="$APP_NAME_SFX" --build-cache
+            -PAPP_ID_SFX="$APP_ID_SFX" -PAPP_NAME="$APP_NAME" --build-cache
           mv $out/*.apk dist/arm/
 
       - name: Upload arm64 APK

--- a/fermata/build.gradle
+++ b/fermata/build.gradle
@@ -1,5 +1,10 @@
 if (gradle.ext.enableGoogleServices) apply plugin: 'com.google.gms.google-services'
 
+def appNameSuffix = project.getProperties().getOrDefault('APP_NAME_SFX', '')
+def appName = { String resourceName, String value ->
+    appNameSuffix.isEmpty() ? "@string/${resourceName}" : "${value}${appNameSuffix}"
+}
+
 android {
     defaultConfig {
         namespace = 'me.aap.fermata'
@@ -29,8 +34,8 @@ android {
         release {
             debuggable false
             minifyEnabled true
-            resValue "string", "app_name_auto", "@string/app_name_auto_release"
-            resValue "string", "app_name_mobile", "@string/app_name_mobile_release"
+            resValue "string", "app_name_auto", appName('app_name_auto_release', 'Fermata Auto')
+            resValue "string", "app_name_mobile", appName('app_name_mobile_release', 'Fermata')
             resValue "string", "media_service_name_auto", "@string/media_service_name_auto_release"
             resValue "string", "media_service_name_mobile", "@string/media_service_name_mobile_release"
             resValue "string", "mirror_service_name", "@string/mirror_service_name_release"
@@ -44,8 +49,8 @@ android {
         debug {
             debuggable true
             applicationIdSuffix '.debug'
-            resValue "string", "app_name_auto", "@string/app_name_auto_debug"
-            resValue "string", "app_name_mobile", "@string/app_name_mobile_debug"
+            resValue "string", "app_name_auto", appName('app_name_auto_debug', 'Debug Fermata Auto')
+            resValue "string", "app_name_mobile", appName('app_name_mobile_debug', 'Debug Fermata')
             resValue "string", "media_service_name_auto", "@string/media_service_name_auto_debug"
             resValue "string", "media_service_name_mobile", "@string/media_service_name_mobile_debug"
             resValue "string", "mirror_service_name", "@string/mirror_service_name_debug"

--- a/fermata/build.gradle
+++ b/fermata/build.gradle
@@ -1,10 +1,5 @@
 if (gradle.ext.enableGoogleServices) apply plugin: 'com.google.gms.google-services'
 
-def appNameSuffix = project.getProperties().getOrDefault('APP_NAME_SFX', '')
-def appName = { String resourceName, String value ->
-    appNameSuffix.isEmpty() ? "@string/${resourceName}" : "${value}${appNameSuffix}"
-}
-
 android {
     defaultConfig {
         namespace = 'me.aap.fermata'
@@ -34,8 +29,8 @@ android {
         release {
             debuggable false
             minifyEnabled true
-            resValue "string", "app_name_auto", appName('app_name_auto_release', 'Fermata Auto')
-            resValue "string", "app_name_mobile", appName('app_name_mobile_release', 'Fermata')
+            resValue "string", "app_name_auto", "@string/app_name_auto_release"
+            resValue "string", "app_name_mobile", "@string/app_name_mobile_release"
             resValue "string", "media_service_name_auto", "@string/media_service_name_auto_release"
             resValue "string", "media_service_name_mobile", "@string/media_service_name_mobile_release"
             resValue "string", "mirror_service_name", "@string/mirror_service_name_release"
@@ -49,8 +44,8 @@ android {
         debug {
             debuggable true
             applicationIdSuffix '.debug'
-            resValue "string", "app_name_auto", appName('app_name_auto_debug', 'Debug Fermata Auto')
-            resValue "string", "app_name_mobile", appName('app_name_mobile_debug', 'Debug Fermata')
+            resValue "string", "app_name_auto", "@string/app_name_auto_debug"
+            resValue "string", "app_name_mobile", "@string/app_name_mobile_debug"
             resValue "string", "media_service_name_auto", "@string/media_service_name_auto_debug"
             resValue "string", "media_service_name_mobile", "@string/media_service_name_mobile_debug"
             resValue "string", "mirror_service_name", "@string/mirror_service_name_debug"
@@ -65,7 +60,8 @@ android {
     productFlavors {
         mobile {
             dimension "version"
-            resValue "string", "app_name", "@string/app_name_mobile"
+            resValue "string", "app_name", project.getProperties()
+                    .getOrDefault('APP_NAME', "@string/app_name_mobile")
             resValue "string", "media_service_name", "@string/media_service_name_mobile"
             resValue "drawable", "media_service_icon", "@drawable/launcher"
             buildConfigField "boolean", 'AUTO', 'false'
@@ -75,7 +71,8 @@ android {
         auto {
             dimension "version"
             applicationIdSuffix '.auto' + project.getProperties().getOrDefault('APP_ID_SFX', '')
-            resValue "string", "app_name", "@string/app_name_auto"
+            resValue "string", "app_name", project.getProperties()
+                    .getOrDefault('APP_NAME', "@string/app_name_auto")
             resValue "string", "media_service_name", "@string/media_service_name_auto"
             resValue "drawable", "media_service_icon", "@drawable/media_service"
             buildConfigField "boolean", 'AUTO', 'true'


### PR DESCRIPTION
Adds branch-scoped Android Auto test build identifiers so CI APKs can be installed and tested independently from the official release.

Why this is useful:
- Android Auto/DHU test builds can conflict with the released app when they share the same package id but are signed differently. Giving CI test builds a separate package id makes them easier to install, discover, and validate in DHU.
- Building locally is inconvenient on ARM-based development machines because the Android/NDK toolchain is easiest to run reliably in the GitHub Actions environment. This keeps pipeline-built APKs practical for day-to-day testing.
- The package id is based on the fork owner and branch name, not the commit. That means new commits on the same branch update the same installed test app instead of creating a new app each time.
- The short commit is still shown in the generated app name and artifact name, so it remains easy to identify exactly which CI build is installed.

What changed:
- Computes a sanitized `APP_ID_SFX` in the APK workflow using the PR/fork owner and branch name.
- Passes `APP_ID_SFX` into both Auto release APK builds.
- Adds optional `APP_NAME_SFX` support so CI builds display owner/branch and short commit information in the app label.
- Includes the test identifier in uploaded artifact names.

Validation:
- Checked the edited workflow and Gradle file for reported editor errors.
- Ran `git diff --check`.
- Manually verified the package suffix sanitizer with branch names containing uppercase letters, slashes, hyphens, dots, and a leading number.

The actual APK build remains validated by the GitHub Actions pipeline.